### PR TITLE
feat: onboard cynkra/claude-code-web to Renovate

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,7 +18,8 @@
     "cynkra/runner",
     "cynkra/aws-*",
     "cynkra/cynkraweb",
-    "cynkra/renovate-config"
+    "cynkra/renovate-config",
+    "cynkra/claude-code-web"
     // "!cynkra/cynkraweb-assets",
     // "!cynkra/FBEA",
     // "!cynkra/dynafilter",


### PR DESCRIPTION
## Summary

- Add `cynkra/claude-code-web` to the `autodiscoverFilter` allow-list in
  `default.json`, so Renovate starts managing dependency updates for that
  repository.

## Test plan

- N/A — config-only change, no build or test suite in this repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMpijScgdHrHX9L2cyQQno)_